### PR TITLE
Add option for filetype of compressed images

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ optional arguments:
                         Quality value for image compression (0-100), defaults to 50
   -b BITRATE, --bitrate BITRATE
                         ffmpeg-compliant bitrate value for audio compression, defaults to 48k
+  -t {jpg,jpeg,png,tif,tiff,gif,webp}, --image_type {jpg,jpeg,png,tif,tiff,gif,webp} 
+  		        Filetype for image compression, defaults to jpeg	
 ```
 
 Here's an example of compressing a file `input.apkg` and writing the output to `output.apkg`:
 
 ```bash
-anki-compressor -i input.apkg -o output.apkg -q 50 -b 64k
+anki-compressor -i input.apkg -o output.apkg -q 50 -b 64k -t jpeg
 ```
 
 ### Arguments
@@ -42,3 +44,4 @@ anki-compressor -i input.apkg -o output.apkg -q 50 -b 64k
 - `-o`: Output file name, defaults to `MIN_<INPUT>`
 - `-q`: Image quality on a scale of 1-100 supplied to Pillow's image processing, defaults to 50
 - `-b`: Bitrate for audio output, defaults to '48k'
+- `-t`: Filetype for image compression, defaults to jpeg 

--- a/anki_compressor/__main__.py
+++ b/anki_compressor/__main__.py
@@ -55,7 +55,7 @@ def compress_image(ext, image_bytes, quality=50):
     try:
         im = Image.open(img_buf)
         output_buf = BytesIO()
-        im.convert("RGB").save(output_buf, "JPEG", optimize=True, quality=quality)
+        im.convert("RGB").save(output_buf, ext, optimize=True, quality=quality)
 
         return output_buf.getvalue()
     except Exception:
@@ -117,6 +117,14 @@ def main():
         default="48k",
         help="ffmpeg-compliant bitrate value for audio compression, defaults to 48k",
     )
+    parser.add_argument(
+        "-t",
+        "--image_type",
+        dest="image_type",
+        default="jpeg",
+        choices=IMAGE_EXT,
+        help="Filetype for image compression, defaults to jpeg",
+    )
 
     args = parser.parse_args()
 
@@ -153,10 +161,12 @@ def main():
         ext = v.split(".")[-1].lower()
         contents = None
         if ext in IMAGE_EXT:
-            contents = compress_image(ext, anki_zip.read(k), quality=args.quality)
+            contents = compress_image(
+                args.image_type, anki_zip.read(k), quality=args.quality
+            )
             if contents is not None:
-                update_db(conn, cur, v, "jpg")
-                v = ".".join([".".join(v.split(".")[:-1]), "jpg"])
+                update_db(conn, cur, v, args.image_type)
+                v = ".".join([".".join(v.split(".")[:-1]), args.image_type])
         elif ext in AUDIO_EXT:
             contents = compress_audio(ext, anki_zip.read(k), bitrate=args.bitrate)
             if contents is not None:

--- a/anki_compressor/__main__.py
+++ b/anki_compressor/__main__.py
@@ -48,6 +48,11 @@ def update_db(conn, cur, filename, ext):
 
 
 def compress_image(ext, image_bytes, quality=50):
+
+    # PIL does not recognize .tif extension
+    if ext == "tif":
+        ext = "tiff"
+
     img_buf = BytesIO()
     img_buf.write(image_bytes)
     img_buf.seek(0)
@@ -55,7 +60,7 @@ def compress_image(ext, image_bytes, quality=50):
     try:
         im = Image.open(img_buf)
         output_buf = BytesIO()
-        im.convert("RGB").save(output_buf, ext, optimize=True, quality=quality)
+        im.convert("RGB").save(output_buf, format=ext, optimize=True, quality=quality)
 
         return output_buf.getvalue()
     except Exception:


### PR DESCRIPTION
Resolves #2 

- Added option to pass in a file type for compressed images; replacing the static "jpeg" conversion. 
- Updated README